### PR TITLE
Update ufunc_docstrings.py

### DIFF
--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -3365,7 +3365,7 @@ add_newdoc('numpy.core.umath', 'sinh',
 
 add_newdoc('numpy.core.umath', 'sqrt',
     """
-    Return the positive square-root of an array, element-wise.
+    Return the non-negative square-root of an array, element-wise.
 
     Parameters
     ----------


### PR DESCRIPTION
The expression "the positive square-root" is not correct because the result might be zero. It should be "the non-negative square-root."